### PR TITLE
Fix wasm-wnfs issues (type annotations, putBlock signature)

### DIFF
--- a/crates/wasm/examples/graph/src/blockstore.ts
+++ b/crates/wasm/examples/graph/src/blockstore.ts
@@ -21,9 +21,10 @@ export class MemoryBlockStore {
   }
 
   /** Retrieves an array of bytes from the block store with given CID. */
-  async putBlock(bytes: Uint8Array, code: number): Promise<void> {
+  async putBlock(bytes: Uint8Array, code: number): Promise<Uint8Array> {
     const hash = await sha256.digest(bytes);
     const cid = CID.create(1, code, hash);
     this.store.set(cid.toString(), bytes);
+    return cid.bytes;
   }
 }

--- a/crates/wasm/examples/graph/src/types.ts
+++ b/crates/wasm/examples/graph/src/types.ts
@@ -4,7 +4,7 @@ export type Nullable<T> = T | null;
 
 export interface BlockStore {
   getBlock(cid: Uint8Array): Promise<Uint8Array | undefined>;
-  putBlock(bytes: Uint8Array, code: number): Promise<void>;
+  putBlock(bytes: Uint8Array, code: number): Promise<Uint8Array>;
 }
 
 export type Handler = ((e: Event) => void) | ((e: Event) => Promise<void>);

--- a/crates/wasm/fs/blockstore.rs
+++ b/crates/wasm/fs/blockstore.rs
@@ -18,6 +18,7 @@ use wnfs::{
 
 #[wasm_bindgen]
 extern "C" {
+    #[wasm_bindgen(typescript_type = "BlockStore")]
     pub type BlockStore;
 
     #[wasm_bindgen(method, js_name = "putBlock")]

--- a/crates/wasm/fs/mod.rs
+++ b/crates/wasm/fs/mod.rs
@@ -1,5 +1,6 @@
 mod blockstore;
 mod public;
+mod types;
 
 pub use blockstore::*;
 pub use public::*;

--- a/crates/wasm/fs/types.rs
+++ b/crates/wasm/fs/types.rs
@@ -1,0 +1,9 @@
+use wasm_bindgen::prelude::wasm_bindgen;
+
+#[wasm_bindgen(typescript_custom_section)]
+const TS_BLOCKSTORE: &'static str = r#"
+export interface BlockStore {
+    putBlock(bytes: Uint8Array, code: number): Promise<Uint8Array>;
+    getBlock(cid: Uint8Array): Promise<Uint8Array | undefined>;
+}
+"#;

--- a/crates/wasm/lib.rs
+++ b/crates/wasm/lib.rs
@@ -1,5 +1,5 @@
 #![allow(clippy::unused_unit)] // To prevent clippy screaming about wasm_bindgen macros.
-#![cfg(target_arch = "wasm32")]
+#![cfg(target_arch = "wasm32")] // This project only makes sense as a wasm32 target.
 use wasm_bindgen::prelude::wasm_bindgen;
 
 pub mod fs;

--- a/crates/wasm/tests/mock.ts
+++ b/crates/wasm/tests/mock.ts
@@ -26,10 +26,11 @@ class MemoryBlockStore {
   }
 
   /** Retrieves an array of bytes from the block store with given CID. */
-  async putBlock(bytes: Uint8Array, code: number): Promise<void> {
+  async putBlock(bytes: Uint8Array, code: number): Promise<Uint8Array> {
     const hash = await sha256.digest(bytes);
     const cid = CID.create(1, code, hash);
     this.store.set(cid.toString(), bytes);
+    return cid.bytes;
   }
 }
 


### PR DESCRIPTION
## Summary

Getting wasm-bindgen to generate more precise type annotations for ts and fixing the putBlock signature

<!-- Summary of the PR -->

This PR implements the following **features**

- [x] Generate precise type annotations
- [x] Fix putBlock signature

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

## Test plan (required)

- Testing the wasm bindings.
  
  ```bash
  cd crates/wasm
  ```
  
  ```bash
  yarn playwright test
  ```

<!-- Make sure tests pass on Circle CI. -->

## Closing issues

<!-- Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such). -->

Fixes https://github.com/WebNativeFileSystem/rs-wnfs/issues/33
Fixes https://github.com/WebNativeFileSystem/rs-wnfs/issues/32